### PR TITLE
Use aws > 3.0 provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Use aws > 3.0 provider

## why
* Take advantage of the latest changes

## references
N/A

