### PR TITLE
add az relocation var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,11 @@ resource "aws_redshift_cluster" "default" {
   node_type          = var.node_type
   cluster_type       = var.cluster_type
 
-  vpc_security_group_ids       = var.vpc_security_groups
-  cluster_subnet_group_name    = join("", aws_redshift_subnet_group.default.*.id)
-  availability_zone            = var.availability_zone
-  preferred_maintenance_window = var.preferred_maintenance_window
+  vpc_security_group_ids               = var.vpc_security_groups
+  cluster_subnet_group_name            = join("", aws_redshift_subnet_group.default.*.id)
+  availability_zone                    = var.availability_zone
+  availability_zone_relocation_enabled = var.availability_zone_relocation_enabled
+  preferred_maintenance_window         = var.preferred_maintenance_window
 
   cluster_parameter_group_name        = join("", aws_redshift_parameter_group.default.*.id)
   automated_snapshot_retention_period = var.automated_snapshot_retention_period

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "availability_zone" {
   description = "Optional parameter to place Amazon Redshift cluster instances in a specific availability zone. If left empty, will place randomly"
 }
 
+variable "availability_zone_relocation_enabled" {
+  type        = bool
+  default     = false
+  description = "If true, the cluster can be relocated to another availabity zone, either automatically by AWS or when requested"
+}
+
 variable "preferred_maintenance_window" {
   type        = string
   default     = null

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.6"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
* add `availability_zone_relocation_enabled`

## why
* allow users to enable
* defaults to `null` if the aws provider is v4.6 or newer 
    * this is not a desired affect so allow it to be configiable 

## references
* https://github.com/hashicorp/terraform-provider-aws/pull/20812

