### PR TITLE
Setup logging via aws_redshift_logging resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,18 +36,16 @@ resource "aws_redshift_cluster" "default" {
   iam_roles                           = var.iam_roles
   allow_version_upgrade               = var.allow_version_upgrade
 
-  logging {
-    enable        = var.logging_enabled
-    bucket_name   = var.logging_bucket_name
-    s3_key_prefix = var.logging_s3_key_prefix
-  }
-
   depends_on = [
     aws_redshift_subnet_group.default,
     aws_redshift_parameter_group.default
   ]
 
   tags = module.this.tags
+
+  lifecycle {
+    ignore_changes = [logging]
+  }
 }
 
 resource "aws_redshift_subnet_group" "default" {
@@ -75,4 +73,15 @@ resource "aws_redshift_parameter_group" "default" {
   }
 
   tags = module.this.tags
+}
+
+resource "aws_redshift_logging" "default" {
+  count = local.enabled && var.logging_enabled ? 1 : 0
+
+  cluster_identifier   = aws_redshift_cluster.default[0].id
+  log_destination_type = var.logging_log_destination_type
+  log_exports          = var.logging_log_exports
+
+  bucket_name   = var.logging_bucket_name
+  s3_key_prefix = var.logging_s3_key_prefix
 }

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,18 @@ variable "logging_enabled" {
   description = "If true, enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster"
 }
 
+variable "logging_log_destination_type" {
+  type        = string
+  default     = null
+  description = "Log destination type for the Redshift cluster ('s3' or 'cloudwatch')."
+}
+
+variable "logging_log_exports" {
+  type        = list(string)
+  default     = []
+  description = "Log destination types for the cluster (one or more of 'connectionlog', 'useractivitylog', 'userlog')."
+}
+
 variable "logging_bucket_name" {
   type        = string
   default     = null


### PR DESCRIPTION
## what

Redshift cluster audit logging is now setup using the separate [aws_redshift_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_logging) Terraform resource, as recommended by the upstream docs. Support for setting up logging to CloudWatch is added on top of the already-supported S3 log destination.

## why

The original `logging` parameter directly on the `aws_redshift_cluster` resource [is now marked as deprecated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#logging).

## references

Closes #38.