### PR TITLE
ignoring changes to maintenance_track_name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_redshift_cluster" "default" {
   owner_account                       = var.owner_account
   iam_roles                           = var.iam_roles
   allow_version_upgrade               = var.allow_version_upgrade
+  maintenance_track_name              = var.maintenance_track_name
 
   logging {
     enable        = var.logging_enabled

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,10 @@ resource "aws_redshift_cluster" "default" {
     aws_redshift_parameter_group.default
   ]
 
+  lifecycle {
+    ignore_changes = [maintenance_track_name]
+  }
+
   tags = module.this.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,9 @@ variable "availability_zone_relocation_enabled" {
   default     = false
   description = "Whether or not the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Available for use on clusters from the RA3 instance family"
 }
+
+variable "maintenance_track_name" {
+  type        = string
+  default     = current
+  description = "Whether or not to enable major version upgrades which are applied during the maintenance window to the Amazon Redshift engine that is running on the cluster"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,6 @@ variable "availability_zone_relocation_enabled" {
 
 variable "maintenance_track_name" {
   type        = string
-  default     = current
+  default     = "current"
   description = "The name of the maintenance track for the restored cluster."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -189,5 +189,5 @@ variable "availability_zone_relocation_enabled" {
 variable "maintenance_track_name" {
   type        = string
   default     = current
-  description = "Whether or not to enable major version upgrades which are applied during the maintenance window to the Amazon Redshift engine that is running on the cluster"
+  description = "The name of the maintenance track for the restored cluster."
 }


### PR DESCRIPTION
## what
Ignore changes to the Terraform variable maintenance_track_name for the Redshift cluster resource.

## why
Terraform is attempting to update maintenance_track_name due to a value managed outside our Terraform configuration. Since AWS does not allow us to explicitly set this value in our configuration, the change is being ignored to prevent unnecessary updates.

Example plan output:
```
# aws_redshift_cluster.default will be updated in-place
  ~ resource "aws_redshift_cluster" "default" {
        id                                   = "paystack-staging-data-platform"
      ~ maintenance_track_name               = "dc2ltm" -> "current"
    }

```
