### PR TITLE
manage maintenance_track_name parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_redshift_cluster" "default" {
   owner_account                       = var.owner_account
   iam_roles                           = var.iam_roles
   allow_version_upgrade               = var.allow_version_upgrade
+  maintenance_track_name              = var.maintenance_track_name
 
   logging {
     enable        = var.logging_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,9 @@ variable "availability_zone_relocation_enabled" {
   default     = false
   description = "Whether or not the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Available for use on clusters from the RA3 instance family"
 }
+
+variable "maintenance_track_name" {
+  type        = string
+  default     = null
+  description = "The name of the maintenance track for the restored cluster"
+}


### PR DESCRIPTION
## what
- Add 'maintenance_track_name' as variable to manage this parameter

## why
- Required for old implementations with deprecated intance type (e.g. dc2)

## references
- N/A
