### PR TITLE
fix(tests): Address failing tests and migrate `logging` to `aws_redshift_logging`

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,7 +16,7 @@ admin_password = "Admin_Password_1"
 
 database_name = "test"
 
-node_type = "dc2.large"
+node_type = "ra3.large"
 
 cluster_type = "single-node"
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -25,3 +25,9 @@ engine_version = "1.0"
 publicly_accessible = false
 
 allow_version_upgrade = false
+
+logging_enabled = true
+
+logging_destination_type = "cloudwatch"
+
+logging_exports = ["connectionlog", "userlog"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnet" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.0.2"
+  version = "2.4.2"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -66,5 +66,9 @@ module "redshift_cluster" {
   publicly_accessible   = var.publicly_accessible
   allow_version_upgrade = var.allow_version_upgrade
 
+  logging_enabled          = var.logging_enabled
+  logging_destination_type = var.logging_destination_type
+  logging_exports          = var.logging_exports
+
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -60,3 +60,27 @@ variable "allow_version_upgrade" {
   default     = false
   description = "Whether or not to enable major version upgrades which are applied during the maintenance window to the Amazon Redshift engine that is running on the cluster"
 }
+
+variable "logging_enabled" {
+  type        = bool
+  default     = false
+  description = "If true, enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster"
+}
+
+variable "logging_destination_type" {
+  type        = string
+  default     = "s3"
+  description = "Log destination type. Valid values are `s3` and `cloudwatch`."
+
+  validation {
+    condition     = contains(["s3", "cloudwatch"], var.logging_destination_type)
+    error_message = "Invalid logging destination type. Valid values are `s3` and `cloudwatch`."
+  }
+}
+
+variable "logging_exports" {
+  type        = list(string)
+  default     = []
+  description = "A list of log types to be enabled. Valid values are `userlog`, `connectionlog`, and `useractivitylog`."
+}
+

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  enabled = module.this.enabled
+  enabled         = module.this.enabled
+  logging_enabled = module.this.enabled && var.logging_enabled
 }
 
 resource "aws_redshift_cluster" "default" {
@@ -36,18 +37,22 @@ resource "aws_redshift_cluster" "default" {
   iam_roles                           = var.iam_roles
   allow_version_upgrade               = var.allow_version_upgrade
 
-  logging {
-    enable        = var.logging_enabled
-    bucket_name   = var.logging_bucket_name
-    s3_key_prefix = var.logging_s3_key_prefix
-  }
-
   depends_on = [
     aws_redshift_subnet_group.default,
     aws_redshift_parameter_group.default
   ]
 
   tags = module.this.tags
+}
+
+resource "aws_redshift_logging" "this" {
+  count = local.logging_enabled ? 1 : 0
+
+  cluster_identifier   = one(aws_redshift_cluster.default[*].id)
+  log_destination_type = var.logging_destination_type
+  log_exports          = var.logging_exports
+  bucket_name          = var.logging_bucket_name
+  s3_key_prefix        = var.logging_s3_key_prefix
 }
 
 resource "aws_redshift_subnet_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,23 @@ variable "logging_enabled" {
   description = "If true, enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster"
 }
 
+variable "logging_destination_type" {
+  type        = string
+  default     = "s3"
+  description = "Log destination type. Valid values are `s3` and `cloudwatch`."
+
+  validation {
+    condition     = contains(["s3", "cloudwatch"], var.logging_destination_type)
+    error_message = "Invalid logging destination type. Valid values are `s3` and `cloudwatch`."
+  }
+}
+
+variable "logging_exports" {
+  type        = list(string)
+  default     = []
+  description = "A list of log types to be enabled. Valid values are `userlog`, `connectionlog`, and `useractivitylog`."
+}
+
 variable "logging_bucket_name" {
   type        = string
   default     = null


### PR DESCRIPTION
## what

- [X] Migrate the deprecated and removed `logging` dynamic block to `aws_redshift_logging`
- [X] Update tests to ensure backwards compatibility while testing new functionality
- [X] Bump testing `subnet` module

## why

- Fix failing tests holding up other PRs
- Fixes the tests for this contribution: #48 
- [X] Support CloudWatch logging destinations


## references

- [Terraform Docs](https://registry.terraform.io/providers/hashicorp/awS/latest/docs/resources/redshift_logging)
